### PR TITLE
Add note name input support and canvas box labels

### DIFF
--- a/motion_to_midi/activity_midi/core.js
+++ b/motion_to_midi/activity_midi/core.js
@@ -587,14 +587,22 @@ function noteNameToMidi(str) {
     return midi;
 }
 
+function getMappingNote(id) {
+    var m = state.mappings[id];
+    return (m !== null && typeof m === 'object') ? m.v : m;
+}
+function getMappingLabel(id) {
+    var m = state.mappings[id];
+    return (m !== null && typeof m === 'object') ? m.l : String(m);
+}
+
 var state = {
     boxEnabled: [],
     height: 4,
     width: 5,
     smoothing: 3,
     mappings: {
-    }, // for boxes
-    mappingLabels: {}, // display strings for box notes (raw user input)
+    }, // for boxes; values are either an int or {v:<int>, l:<string>} when user typed a note name
     angles: [],
     dist: [],
     xy:[],
@@ -683,7 +691,7 @@ function updateDisplayWithState() {
             document.getElementById("checkbox" + id).checked = id in state.mappings
             if (id in state.mappings) {
                 document.getElementById("midiNumb" + id).disabled = false
-                document.getElementById("midiNumb" + id).value = (state.mappingLabels && state.mappingLabels[id]) || state.mappings[id]
+                document.getElementById("midiNumb" + id).value = getMappingLabel(id)
             } else {
                 document.getElementById("midiNumb" + id).value = ""
                 document.getElementById("midiNumb" + id).disabled = true
@@ -1201,11 +1209,8 @@ function drawActiveBoxes() {
                 var id = event.srcElement.myIndex
                 if (event.srcElement.checked) {
                     state.mappings[id] = newCandidateNumber(id)
-                    if (!state.mappingLabels) state.mappingLabels = {};
-                    state.mappingLabels[id] = String(state.mappings[id]);
                 } else {
                     delete state.mappings[id]
-                    if (state.mappingLabels) delete state.mappingLabels[id];
                 }
                 state.mappings[id]
                 stateHasBeenUpdated()
@@ -1227,17 +1232,14 @@ function drawActiveBoxes() {
                     isNumber = true;
                     raw = String(newVal);
                 }
-                state.mappings[event.srcElement.myIndex] = newVal;
-                if (!state.mappingLabels) state.mappingLabels = {};
-                state.mappingLabels[event.srcElement.myIndex] = raw;
+                state.mappings[event.srcElement.myIndex] = isNumber ? newVal : { v: newVal, l: raw };
                 var noteLabel = document.getElementById("noteLabel" + event.srcElement.myIndex);
                 noteLabel.innerHTML = isNumber ? " " + toNoteName(newVal) : "";
                 stateHasBeenUpdated();
             })
             if(state.mappings[id]){
-                var storedLabel = state.mappingLabels && state.mappingLabels[id];
-                var labelIsNumber = !storedLabel || (String(parseInt(storedLabel)) === storedLabel);
-                myNoteLabel.innerHTML = labelIsNumber ? " " + toNoteName(state.mappings[id]) : "";
+                var labelIsNumber = typeof state.mappings[id] !== 'object';
+                myNoteLabel.innerHTML = labelIsNumber ? " " + toNoteName(getMappingNote(id)) : "";
             }
 
             iDiv.appendChild(checkbox)
@@ -1310,11 +1312,11 @@ document.getElementById("widthTextBox").onchange = (event) => {
 }
 
 function sendNoteOn(id) {
-    sendToMidi([0x90, state.mappings[id], 0x7f])
+    sendToMidi([0x90, getMappingNote(id), 0x7f])
 }
 
 function sendNoteOff(id) {
-    sendToMidi([0x80, state.mappings[id], 0])
+    sendToMidi([0x80, getMappingNote(id), 0])
 }
 
 function sendMidiCC(ccChan, val, max) {
@@ -1380,7 +1382,7 @@ function doWholeSpecificFunction(result) {
                 canvasCtx.fill();
             }
             if (w + "-" + h in state.mappings) {
-                var noteLabel = (state.mappingLabels && state.mappingLabels[w + "-" + h]) || toNoteName(state.mappings[w + "-" + h]);
+                var noteLabel = getMappingLabel(w + "-" + h);
                 canvasCtx.fillStyle = colorParams[colorID].primaryOutline;
                 canvasCtx.font = "bold 25px Roboto";
                 var notePad = 5;
@@ -2088,12 +2090,15 @@ function updateStateToWorkWithCurrentStateObject(validState, newState){
         }
         delete newState['xySending']
     }
-    // Backfill mappingLabels for any mapped boxes missing a display label
-    if (!newState.mappingLabels) newState.mappingLabels = {};
-    for (var k in newState.mappings) {
-        if (!(k in newState.mappingLabels)) {
-            newState.mappingLabels[k] = String(newState.mappings[k]);
+    // Migrate old mappingLabels format: fold labels into mappings entries
+    if (newState.mappingLabels) {
+        for (var k in newState.mappingLabels) {
+            var label = newState.mappingLabels[k];
+            if (k in newState.mappings && (isNaN(parseInt(label)) || String(parseInt(label)) !== label)) {
+                newState.mappings[k] = { v: newState.mappings[k], l: label };
+            }
         }
+        delete newState.mappingLabels;
     }
 
     // Only add emotions array if face model is selected

--- a/motion_to_midi/activity_midi/core.js
+++ b/motion_to_midi/activity_midi/core.js
@@ -2091,17 +2091,6 @@ function updateStateToWorkWithCurrentStateObject(validState, newState){
         }
         delete newState['xySending']
     }
-    // Migrate old mappingLabels format: fold labels into mappings entries
-    if (newState.mappingLabels) {
-        for (var k in newState.mappingLabels) {
-            var label = newState.mappingLabels[k];
-            if (k in newState.mappings && (isNaN(parseInt(label)) || String(parseInt(label)) !== label)) {
-                newState.mappings[k] = { v: newState.mappings[k], l: label };
-            }
-        }
-        delete newState.mappingLabels;
-    }
-
     // Only add emotions array if face model is selected
     if (newState.md === "f-fa" && !('emotions' in newState)) {
         newState.emotions = [];

--- a/motion_to_midi/activity_midi/core.js
+++ b/motion_to_midi/activity_midi/core.js
@@ -1208,7 +1208,8 @@ function drawActiveBoxes() {
             checkbox.addEventListener('change', (event) => {
                 var id = event.srcElement.myIndex
                 if (event.srcElement.checked) {
-                    state.mappings[id] = newCandidateNumber(id)
+                    var n = newCandidateNumber(id);
+                    state.mappings[id] = { v: n, l: toNoteName(n) };
                 } else {
                     delete state.mappings[id]
                 }

--- a/motion_to_midi/activity_midi/core.js
+++ b/motion_to_midi/activity_midi/core.js
@@ -574,6 +574,19 @@ function toNoteName(midiNote) {
     return noteNames[noteIndex] + octave;
 }
 
+function noteNameToMidi(str) {
+    var match = str.trim().match(/^([A-Ga-g])([#b]?)(-?\d+)$/);
+    if (!match) return null;
+    var noteNames = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+    var noteIndex = noteNames.indexOf(match[1].toUpperCase());
+    if (match[2] === '#') noteIndex += 1;
+    if (match[2] === 'b') noteIndex -= 1;
+    noteIndex = ((noteIndex % 12) + 12) % 12;
+    var midi = (parseInt(match[3]) + 1) * 12 + noteIndex;
+    if (midi < 0 || midi > 127) return null;
+    return midi;
+}
+
 var state = {
     boxEnabled: [],
     height: 4,
@@ -581,6 +594,7 @@ var state = {
     smoothing: 3,
     mappings: {
     }, // for boxes
+    mappingLabels: {}, // display strings for box notes (raw user input)
     angles: [],
     dist: [],
     xy:[],
@@ -669,7 +683,7 @@ function updateDisplayWithState() {
             document.getElementById("checkbox" + id).checked = id in state.mappings
             if (id in state.mappings) {
                 document.getElementById("midiNumb" + id).disabled = false
-                document.getElementById("midiNumb" + id).value = state.mappings[id]
+                document.getElementById("midiNumb" + id).value = (state.mappingLabels && state.mappingLabels[id]) || state.mappings[id]
             } else {
                 document.getElementById("midiNumb" + id).value = ""
                 document.getElementById("midiNumb" + id).disabled = true
@@ -1175,6 +1189,7 @@ function drawActiveBoxes() {
             myLabel.innerHTML = id
 
             var myNoteLabel = document.createElement('span');
+            myNoteLabel.id = "noteLabel" + id;
 
             iDiv.id = 'box-' + id;
 
@@ -1186,8 +1201,11 @@ function drawActiveBoxes() {
                 var id = event.srcElement.myIndex
                 if (event.srcElement.checked) {
                     state.mappings[id] = newCandidateNumber(id)
+                    if (!state.mappingLabels) state.mappingLabels = {};
+                    state.mappingLabels[id] = String(state.mappings[id]);
                 } else {
                     delete state.mappings[id]
+                    if (state.mappingLabels) delete state.mappingLabels[id];
                 }
                 state.mappings[id]
                 stateHasBeenUpdated()
@@ -1199,20 +1217,27 @@ function drawActiveBoxes() {
             inputField.id = "midiNumb" + id
 
             inputField.addEventListener('change', (event) => {
-
-                var newVal = parseInt(event.srcElement.value)
-                console.log(newVal)
-                if (newVal > 128) {
-                    newVal = newCandidateNumber(id)
+                var raw = event.srcElement.value.trim();
+                var asInt = parseInt(raw);
+                var isNumber = !isNaN(asInt) && String(asInt) === raw;
+                var newVal = isNumber ? asInt : noteNameToMidi(raw);
+                if (newVal === null || newVal === undefined || isNaN(newVal) || newVal > 127 || newVal < 0) {
+                    newVal = newCandidateNumber(event.srcElement.myIndex);
+                    event.srcElement.value = newVal;
+                    isNumber = true;
+                    raw = String(newVal);
                 }
-                if (newVal < 0) {
-                    newVal = newCandidateNumber(id)
-                }
-                state.mappings[event.srcElement.myIndex] = newVal
-                stateHasBeenUpdated()
+                state.mappings[event.srcElement.myIndex] = newVal;
+                if (!state.mappingLabels) state.mappingLabels = {};
+                state.mappingLabels[event.srcElement.myIndex] = raw;
+                var noteLabel = document.getElementById("noteLabel" + event.srcElement.myIndex);
+                noteLabel.innerHTML = isNumber ? " " + toNoteName(newVal) : "";
+                stateHasBeenUpdated();
             })
             if(state.mappings[id]){
-                myNoteLabel.innerHTML = " " +toNoteName(state.mappings[id])
+                var storedLabel = state.mappingLabels && state.mappingLabels[id];
+                var labelIsNumber = !storedLabel || (String(parseInt(storedLabel)) === storedLabel);
+                myNoteLabel.innerHTML = labelIsNumber ? " " + toNoteName(state.mappings[id]) : "";
             }
 
             iDiv.appendChild(checkbox)
@@ -1353,6 +1378,17 @@ function doWholeSpecificFunction(result) {
                 canvasCtx.fillStyle = colorParams[colorID].accentColor2;
                 canvasCtx.rect(w * wunit, h * hunit, wunit, hunit);
                 canvasCtx.fill();
+            }
+            if (w + "-" + h in state.mappings) {
+                var noteLabel = (state.mappingLabels && state.mappingLabels[w + "-" + h]) || toNoteName(state.mappings[w + "-" + h]);
+                canvasCtx.fillStyle = colorParams[colorID].primaryOutline;
+                canvasCtx.font = "bold 25px Roboto";
+                var notePad = 5;
+                canvasCtx.save();
+                canvasCtx.translate((w + 1) * wunit - notePad, h * hunit + notePad + 25);
+                canvasCtx.scale(-1, 1);
+                canvasCtx.fillText(noteLabel, 0, 0);
+                canvasCtx.restore();
             }
         }
     }
@@ -2052,6 +2088,14 @@ function updateStateToWorkWithCurrentStateObject(validState, newState){
         }
         delete newState['xySending']
     }
+    // Backfill mappingLabels for any mapped boxes missing a display label
+    if (!newState.mappingLabels) newState.mappingLabels = {};
+    for (var k in newState.mappings) {
+        if (!(k in newState.mappingLabels)) {
+            newState.mappingLabels[k] = String(newState.mappings[k]);
+        }
+    }
+
     // Only add emotions array if face model is selected
     if (newState.md === "f-fa" && !('emotions' in newState)) {
         newState.emotions = [];


### PR DESCRIPTION
## Summary

- Box note input fields now accept note names (`C4`, `F#3`, `Bb2`, etc.) in addition to raw MIDI numbers
- The input field keeps whatever the user typed — `48` stays `48`, `C4` stays `C4`
- When the user types a number, the existing note name label (e.g. `C4`) still appears next to it; when they type a note name, the label is hidden since it's redundant
- Newly checked boxes default to a note name (e.g. `C3`) rather than a raw number
- Each mapped box now shows its label (number or note name) in the top-left corner of the canvas overlay

## Implementation notes

- `mappings[id]` is either a bare int (when user typed a number) or `{v, l}` (when user typed a note name) — no separate top-level key so state stays compact
- `getMappingNote(id)` / `getMappingLabel(id)` helpers abstract over both formats
- Canvas text uses the same `scale(-1, 1)` mirror trick as face labels to render correctly under the CSS `rotateY(180deg)` flip

## Test plan

- [ ] Check a box — input and canvas both show a note name (e.g. `C3`), no redundant label next to input
- [ ] Type a number (e.g. `54`) — input stays `54`, `F#3` label appears next to it, canvas shows `54`
- [ ] Type a note name (e.g. `C4`) — input stays `C4`, no label next to it, canvas shows `C4`
- [ ] Type an invalid value — falls back to a default note name
- [ ] Reload the page — labels persist correctly from the URL state
- [ ] Load a URL with old-format state (bare numbers in mappings, no labels) — canvas shows the number for each box

🤖 Generated with [Claude Code](https://claude.com/claude-code)