### PR TITLE
Fix box/MIDI note desync on rapid entry/exit

### DIFF
--- a/motion_to_midi/activity_midi/core.js
+++ b/motion_to_midi/activity_midi/core.js
@@ -1254,20 +1254,29 @@ function addToRectCount(point, newRectCounts) {
     newRectCounts[w + "-" + h] += 1
 }
 var oldRectCounts = {}
-
-
+var boxNoteState = {}  // true if note is currently on for a given box id
+var boxExitCount = {}  // consecutive frames a marker has been absent from a box
+var EXIT_DEBOUNCE = 3  // frames outside box required before note off fires
 
 function processRectCounts(newRectCounts) {
     for (var w = 0; w < state.width; w++) {
         for (var h = 0; h < state.height; h++) {
-            if ((w + "-" + h in state.mappings)) {
-                if (newRectCounts[w + "-" + h] > 0 && oldRectCounts[w + "-" + h] == 0) {
-                    // send a note on!!!!
-                    sendNoteOn(w + "-" + h)
-                }
-                if (newRectCounts[w + "-" + h] == 0 && oldRectCounts[w + "-" + h] > 0) {
-                    // send a note off!!!!
-                    sendNoteOff(w + "-" + h)
+            var id = w + "-" + h;
+            if (id in state.mappings) {
+                var inBox = (newRectCounts[id] || 0) > 0;
+                if (inBox) {
+                    boxExitCount[id] = 0;
+                    if (!boxNoteState[id]) {
+                        boxNoteState[id] = true;
+                        sendNoteOn(id);
+                    }
+                } else {
+                    boxExitCount[id] = (boxExitCount[id] || 0) + 1;
+                    if (boxNoteState[id] && boxExitCount[id] >= EXIT_DEBOUNCE) {
+                        boxNoteState[id] = false;
+                        boxExitCount[id] = 0;
+                        sendNoteOff(id);
+                    }
                 }
             }
         }
@@ -1349,7 +1358,7 @@ function doWholeSpecificFunction(result) {
                 canvasCtx.rect(w * wunit, h * hunit, wunit, hunit);
                 canvasCtx.fill();
             }
-            if (oldRectCounts[w + "-" + h] > 0 && w + "-" + h in state.mappings) {
+            if (boxNoteState[w + "-" + h] && w + "-" + h in state.mappings) {
                 canvasCtx.fillStyle = colorParams[colorID].accentColor2;
                 canvasCtx.rect(w * wunit, h * hunit, wunit, hunit);
                 canvasCtx.fill();
@@ -1701,13 +1710,14 @@ function clearEverything() {
         sendMidiCC(14 + i, 0, 127)
         prevlandmarks = null
     }
-
-    var emptyRectCounts = {}
-    for (const [key, value] of Object.entries(oldRectCounts)) {
-        emptyRectCounts[key] = 0
+    for (var id in boxNoteState) {
+        if (boxNoteState[id]) {
+            sendNoteOff(id);
+        }
     }
-    processRectCounts(emptyRectCounts)
-    oldRectCounts = emptyRectCounts
+    boxNoteState = {};
+    boxExitCount = {};
+    oldRectCounts = {};
 }
 
 


### PR DESCRIPTION
## Problem

Two bugs caused boxes to appear lit (green) while the MIDI note was off:

1. **1-frame visual/MIDI desync** — the green fill was drawn at the top of each frame using the *previous* frame's counts, while MIDI note on/off fired at the bottom of the same frame. On every box exit, there was a frame where visual=green but note=off.

2. **Boundary jitter** — a marker oscillating on a box edge sent rapid note ON/OFF/ON messages. DAWs can drop or reorder these, leaving the note stuck off while the box stayed green.

## Fix

- Introduce `boxNoteState` as the explicit source of truth for what was last sent to MIDI
- Drive the green fill from `boxNoteState` instead of `oldRectCounts` — visual now always mirrors MIDI with no lag
- Debounce note-off: require `EXIT_DEBOUNCE` (3) consecutive frames outside a box before firing note-off, absorbing boundary jitter without noticeable delay
- Simplify `clearEverything` to iterate `boxNoteState` directly for note-offs

## Test plan

- [ ] Move a marker into a box — note on fires, box turns green
- [ ] Move marker out — box stays green and note stays on for ~3 frames, then both go off together
- [ ] Rapidly wave a marker across a box boundary — no stuck notes
- [ ] Leave frame entirely — `clearEverything` fires note-offs and clears green fills correctly
- [ ] Confirm visual and MIDI are always in sync (no green box with note off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)